### PR TITLE
Disable expression-bodied method rule that auto converts {} methods to =>

### DIFF
--- a/DontPanicLabs.CodeAnalysis/.editorconfig
+++ b/DontPanicLabs.CodeAnalysis/.editorconfig
@@ -97,7 +97,7 @@ dotnet_style_prefer_conditional_expression_over_return = true:silent
 csharp_prefer_simple_default_expression = true:suggestion
 
 # Expression-bodied members
-csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_methods = false
 csharp_style_expression_bodied_constructors = true:silent
 csharp_style_expression_bodied_operators = true:silent
 csharp_style_expression_bodied_properties = true:silent


### PR DESCRIPTION
Team so far using new DPL template has consistently preferred to not have this auto-conversion (I believe expression-bodied members can also cause some debugging pain).

Without the change in this PR, this:
<img width="682" height="291" alt="image" src="https://github.com/user-attachments/assets/d65eaec6-5f5e-4e91-95c9-e12193be5a73" />

changes to this:
<img width="720" height="257" alt="image" src="https://github.com/user-attachments/assets/e84b7060-1183-4f17-9d20-2f5c9b8e1bf8" />

With the change in this PR, it remains unmodified:

<img width="754" height="239" alt="image" src="https://github.com/user-attachments/assets/07f63b5b-2aad-4e34-8824-5e396ea3d515" />


