### PR TITLE
Preserve object initialization formatting

### DIFF
--- a/DontPanicLabs.CodeAnalysis/.editorconfig
+++ b/DontPanicLabs.CodeAnalysis/.editorconfig
@@ -21,7 +21,7 @@ csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_object_initializers = false
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 

--- a/DontPanicLabs.CodeAnalysis/DontPanicLabs.CodeAnalysis.csproj
+++ b/DontPanicLabs.CodeAnalysis/DontPanicLabs.CodeAnalysis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageId>DontPanicLabs.CodeAnalysis</PackageId>
     <Title>Don't Panic Labs Code Analysis</Title>
     <Authors>Don't Panic Labs LLC</Authors>


### PR DESCRIPTION
With this set to `true` it was making object initializers single line and hard to read IMO. Setting to false preserves your formatting. Simple cases are ok to leave in-line and the formatter will leave those alone

<img width="901" height="453" alt="image" src="https://github.com/user-attachments/assets/8111d0fd-5665-4538-9991-63aeab398c03" />
