### PR TITLE
Do not require method results to be used

### DIFF
--- a/DontPanicLabs.CodeAnalysis/.editorconfig
+++ b/DontPanicLabs.CodeAnalysis/.editorconfig
@@ -147,7 +147,7 @@ csharp_space_between_square_brackets = false
 # Require braces on all control flow statements 
 dotnet_diagnostic.IDE0011.severity = error
 # Results of expressions must be used
-dotnet_diagnostic.IDE0058.severity = error
+dotnet_diagnostic.IDE0058.severity = none
 # Do not assign values if they are not used
 dotnet_diagnostic.IDE0059.severity = error
 # Do not have unused parameters in methods

--- a/DontPanicLabs.CodeAnalysis/DontPanicLabs.CodeAnalysis.csproj
+++ b/DontPanicLabs.CodeAnalysis/DontPanicLabs.CodeAnalysis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageId>DontPanicLabs.CodeAnalysis</PackageId>
     <Title>Don't Panic Labs Code Analysis</Title>
     <Authors>Don't Panic Labs LLC</Authors>


### PR DESCRIPTION

When set to `error`, it requires every method that has a return value to be used. The workaround in code is to do `_ = ` before each of these lines which hinders readability (imo)
<img width="1032" height="343" alt="image" src="https://github.com/user-attachments/assets/30dd420e-25c6-422b-9e42-71da2486499f" />
