### PR TITLE
Add compiler error if objects are not disposed within scope

### DIFF
--- a/DontPanicLabs.CodeAnalysis/.editorconfig
+++ b/DontPanicLabs.CodeAnalysis/.editorconfig
@@ -152,6 +152,8 @@ dotnet_diagnostic.IDE0058.severity = none
 dotnet_diagnostic.IDE0059.severity = error
 # Do not have unused parameters in methods
 dotnet_diagnostic.IDE0060.severity = error
+# Dispose objects before losing scope
+dotnet_diagnostic.CA2000.severity = error
 
 # JSON files
 [*.json]

--- a/DontPanicLabs.CodeAnalysis/DontPanicLabs.CodeAnalysis.csproj
+++ b/DontPanicLabs.CodeAnalysis/DontPanicLabs.CodeAnalysis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <PackageId>DontPanicLabs.CodeAnalysis</PackageId>
     <Title>Don't Panic Labs Code Analysis</Title>
     <Authors>Don't Panic Labs LLC</Authors>


### PR DESCRIPTION
Example when set to `error`
<img width="2678" height="292" alt="image" src="https://github.com/user-attachments/assets/1dd683bd-9d19-45eb-8c28-54942e894818" />

Can use newer `using` syntax instead of `using(){...}` or `.Dispose()`, but I assume any would technically satisfy the rule
`using var proxyGenerator = new ServiceProxyGenerator(...);`
